### PR TITLE
added backspace key for macOs + iTerm2

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,16 @@ impl Ui {
                         }
                     }
                 }
+                // Backspace code on macOs + iTerm2
+                // source: https://stackoverflow.com/questions/27200597/c-ncurses-key-backspace-not-working
+                127 => {
+                    if *cursor > 0 {
+                        *cursor -= 1;
+                        if *cursor < buffer.len() {
+                            buffer.remove(*cursor);
+                        }
+                    }
+                }
                 constants::KEY_DC => {
                     if *cursor < buffer.len() {
                         buffer.remove(*cursor);


### PR DESCRIPTION
On macOs + iTerm2 the ncurses constants::KEY_BACKSPACE was not a valid backspace character. 
Adding 127 to the fixed the issue and now the backspace is behaving normally.

credits to: https://stackoverflow.com/questions/27200597/c-ncurses-key-backspace-not-working